### PR TITLE
Fix for setting valid values of characteristic thermostatMode

### DIFF
--- a/accessories/he_st_accessories.js
+++ b/accessories/he_st_accessories.js
@@ -791,7 +791,7 @@ function HE_ST_Accessory(platform, device) {
                             break;
                     }
                 });
-            if (that.device.attributes.supportedThermostatModes !== undefined) {    
+            if (typeof that.device.attributes.supportedThermostatModes === 'string') {    
                 var validValuesArray = [];
                 if (that.device.attributes.supportedThermostatModes.includes("off")) {
                     validValuesArray.push(0);


### PR DESCRIPTION
Check that supportedThermostatModes strictly equals a string instead of being strictly unequal to undefined, before setting valid values of characteristic thermostatMode. For thermostat with no set supportedThermostatModes, the following include function would fail for a null object and thus crash the Homebridge-instance. Sorry for the mistake.