### PR TITLE
Fixing an issue with Spring Fashion (Bali) blinds not being recognized

### DIFF
--- a/accessories/he_st_accessories.js
+++ b/accessories/he_st_accessories.js
@@ -75,8 +75,8 @@ function HE_ST_Accessory(platform, device) {
     let isLight = (device.capabilities['LightBulb'] !== undefined || device.capabilities['Light Bulb'] !== undefined || device.capabilities['Bulb'] !== undefined || device.capabilities['Fan Light'] !== undefined || device.capabilities['FanLight'] !== undefined || device.name.includes('light'));
     let isSpeaker = (device.capabilities['Speaker'] !== undefined);
     if (device && device.capabilities) {
-        if ((device.capabilities['Switch Level'] !== undefined || device.capabilities['SwitchLevel'] !== undefined) && !isSpeaker && !isFan && !isMode && !isRoutine && !isWindowShade) {
-            if (device.commands.levelOpenClose || device.commands.presetPosition) {
+        if ((device.capabilities['Switch Level'] !== undefined || device.capabilities['SwitchLevel'] !== undefined) && !isSpeaker && !isFan && !isMode && !isRoutine) {
+            if ((platformName === 'SmartThings' && isWindowShade) || device.commands.levelOpenClose || device.commands.presetPosition) {
                 // This is a Window Shade
                 that.deviceGroup = 'window_shades';
                 thisCharacteristic = that.getaddService(Service.WindowCovering).getCharacteristic(Characteristic.TargetPosition)
@@ -84,9 +84,14 @@ function HE_ST_Accessory(platform, device) {
                         callback(null, parseInt(that.device.attributes.level));
                     })
                     .on('set', function(value, callback) {
-                        platform.api.runCommand(callback, device.deviceid, 'setLevel', {
-                            value1: value
-                        });
+                        if (device.commands.close && value === 0) {
+                            // setLevel: 0, not responding on spring fashion blinds
+                            platform.api.runCommand(callback, device.deviceid, 'close');
+                        } else {
+                            platform.api.runCommand(callback, device.deviceid, 'setLevel', {
+                                value1: value
+                            });
+                        }
                     });
                 platform.addAttributeUsage('level', device.deviceid, thisCharacteristic);
                 thisCharacteristic = that.getaddService(Service.WindowCovering).getCharacteristic(Characteristic.CurrentPosition)
@@ -420,7 +425,7 @@ function HE_ST_Accessory(platform, device) {
                         default:
                             return callback(null, null);
                     }
-                })
+                });
 
             const validValues = [ ];
 


### PR DESCRIPTION
In order to fix an issue stated here - https://github.com/tonesto7/homebridge-smartthings-tonesto7/issues/19, made the following changes:
- Adding an additional isWindowShade check for SmartThings
- Using the close command instead of setLevel 0 for windowShade