### PR TITLE
Update he_st_accessories.js

### DIFF
--- a/accessories/he_st_accessories.js
+++ b/accessories/he_st_accessories.js
@@ -75,7 +75,7 @@ function HE_ST_Accessory(platform, device) {
     let isLight = (device.capabilities['LightBulb'] !== undefined || device.capabilities['Light Bulb'] !== undefined || device.capabilities['Bulb'] !== undefined || device.capabilities['Fan Light'] !== undefined || device.capabilities['FanLight'] !== undefined || device.name.includes('light'));
     let isSpeaker = (device.capabilities['Speaker'] !== undefined);
     if (device && device.capabilities) {
-        if ((device.capabilities['Switch Level'] !== undefined || device.capabilities['SwitchLevel'] !== undefined) && !isSpeaker && !isFan && !isMode && !isRoutine && !isWindowShade) {
+        if ((device.capabilities['Switch Level'] !== undefined || device.capabilities['SwitchLevel'] !== undefined) && !isSpeaker && !isFan && !isMode && !isRoutine) {
             if ((platformName === 'SmartThings' && isWindowShade) || device.commands.levelOpenClose || device.commands.presetPosition) {
                 // This is a Window Shade
                 that.deviceGroup = 'window_shades';


### PR DESCRIPTION
Remove `&& !isWindowShade` conditional check.

This is preventing `if ((platformName === 'SmartThings' && isWindowShade)` from being checked.

See #19.


## Checklist:

-   [x] My code follows the code style of this project.
-   [x] My change requires a change to the documentation.

## Types of changes

Bug fix (non-breaking change which fixes an issue)

## Description of Changes

Removes a conditional check.

## Reason for Change

The next inner conditional will never be reached.

## How Has This Been Tested?

I removed this bit and restarted HomeBridge to confirm that my blinds appear again.