### PR TITLE
Support newer Homebridge API

### DIFF
--- a/accessories/he_st_accessories.js
+++ b/accessories/he_st_accessories.js
@@ -16,6 +16,8 @@ module.exports = function(oAccessory, oService, oCharacteristic, ouuid, platName
         inherits(HE_ST_Accessory, Accessory);
         HE_ST_Accessory.prototype.loadData = loadData;
         HE_ST_Accessory.prototype.getServices = getServices;
+        HE_ST_Accessory.prototype.CreateFromCachedAccessory = CreateFromCachedAccessory;
+        HE_ST_Accessory.prototype.initializeDeviceCharacteristics = initializeDeviceCharacteristics;
     }
     return HE_ST_Accessory;
 };
@@ -25,39 +27,16 @@ function toTitleCase(str) {
     return str.replace(/\w\S*/g, txt => txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase());
 }
 
-function HE_ST_Accessory(platform, device) {
-    // console.log("HE_ST_Accessory: ", platform, device);
-    this.deviceid = device.deviceid;
-    this.name = device.name;
-    this.platform = platform;
-    this.state = {};
-    this.device = device;
-    var idKey = 'hbdev:' + platformName.toLowerCase() + ':' + this.deviceid;
-    var id = uuid.generate(idKey);
-    Accessory.call(this, this.name, id);
-    var that = this;
-
-    //Removing excluded capabilities from config
-    for (var i = 0; i < device.excludedCapabilities.length; i++) {
-        let excludedCapability = device.excludedCapabilities[i];
-        if (device.capabilities[excludedCapability] !== undefined) {
-            platform.log.debug("Removing capability: " + excludedCapability + " for device: " + device.name);
-            delete device.capabilities[excludedCapability];
-        }
-    }
-    that.getService(Service.AccessoryInformation)
-        .setCharacteristic(Characteristic.Identify, (device.capabilities['Switch'] !== undefined))
-        .setCharacteristic(Characteristic.FirmwareRevision, device.firmwareVersion)
-        .setCharacteristic(Characteristic.Manufacturer, device.manufacturerName)
-        .setCharacteristic(Characteristic.Model, `${toTitleCase(device.modelName)}`)
-        .setCharacteristic(Characteristic.Name, that.name)
-        .setCharacteristic(Characteristic.SerialNumber, device.serialNumber);
+function initializeDeviceCharacteristics(accessory, device, platform) {
+    var that = accessory;
+    
     // Get the Capabilities List
     for (var index in device.capabilities) {
         if (platform.knownCapabilities.indexOf(index) === -1 && platform.unknownCapabilities.indexOf(index) === -1) {
             platform.unknownCapabilities.push(index);
         }
     }
+    
     that.getaddService = function(Service) {
         var myService = that.getService(Service);
         if (!myService) {
@@ -65,6 +44,7 @@ function HE_ST_Accessory(platform, device) {
         }
         return myService;
     };
+
     that.deviceGroup = 'unknown'; // that way we can easily tell if we set a device group
     var thisCharacteristic;
     // platform.log(JSON.stringify(device));
@@ -74,6 +54,8 @@ function HE_ST_Accessory(platform, device) {
     let isWindowShade = (device.capabilities['WindowShade'] !== undefined || device.capabilities['Window Shade'] !== undefined);
     let isLight = (device.capabilities['LightBulb'] !== undefined || device.capabilities['Light Bulb'] !== undefined || device.capabilities['Bulb'] !== undefined || device.capabilities['Fan Light'] !== undefined || device.capabilities['FanLight'] !== undefined || device.name.includes('light'));
     let isSpeaker = (device.capabilities['Speaker'] !== undefined);
+    let isSonos = (device.manufacturerName === 'Sonos');
+
     if (device && device.capabilities) {
         if ((device.capabilities['Switch Level'] !== undefined || device.capabilities['SwitchLevel'] !== undefined) && !isSpeaker && !isFan && !isMode && !isRoutine) {
             if ((platformName === 'SmartThings' && isWindowShade) || device.commands.levelOpenClose || device.commands.presetPosition) {
@@ -983,8 +965,95 @@ function HE_ST_Accessory(platform, device) {
                 });
             platform.addAttributeUsage('alarmSystemStatus', device.deviceid, thisCharacteristic);
         }
+
+        // Sonos Speakers
+        if (isSonos && that.deviceGroup === 'unknown' && false) {
+            that.deviceGroup = 'speakers';
+
+            if (that.device.capabilities['Audio Volume']) {
+                var sonosVolumeTimeout = null;
+                var lastVolumeWriteValue = null;
+
+                thisCharacteristic = that.getaddService(Service.Speaker).getCharacteristic(Characteristic.Volume)
+                .on('get', function(callback) {
+                    platform.log.debug("Reading sonos volume " + that.device.attributes.volume);
+                    callback(null, parseInt(that.device.attributes.volume || 0));
+                })
+                .on('set', function(value, callback) {
+                    if (value > 0 && value !== lastVolumeWriteValue) {
+                        lastVolumeWriteValue = value;
+                        platform.log.debug("Existing volume: " + that.device.attributes.volume + ", set to " + value);
+
+                        // Smooth continuous updates to make more responsive
+                        sonosVolumeTimeout = clearAndSetTimeout(sonosVolumeTimeout, function() {
+                            platform.log.debug("Existing volume: " + that.device.attributes.volume + ", set to " + lastVolumeWriteValue);
+
+                            platform.api.runCommand(callback, device.deviceid, 'setVolume', {
+                                value1: lastVolumeWriteValue
+                            });
+                        }, 1000);
+                    }
+                });
+
+                platform.addAttributeUsage('volume', device.deviceid, thisCharacteristic);
+            }
+            
+            if (that.device.capabilities['Audio Mute']) {
+                thisCharacteristic = that.getaddService(Service.Speaker).getCharacteristic(Characteristic.Mute)
+                .on('get', function(callback) {
+                    callback(null, that.device.attributes.mute === 'muted');
+                })
+                .on('set', function(value, callback) {
+                    if (value === 'muted') {
+                        platform.api.runCommand(callback, device.deviceid, 'mute');
+                    } else {
+                        platform.api.runCommand(callback, device.deviceid, 'unmute');
+                    }
+                });
+                platform.addAttributeUsage('mute', device.deviceid, thisCharacteristic);
+            }
+        }
     }
+}
+
+function HE_ST_Accessory(platform, device) {
+    // console.log("HE_ST_Accessory: ", platform, device);
+    this.deviceid = device.deviceid;
+    this.name = device.name;
+    this.platform = platform;
+    this.state = {};
+    this.device = device;
+    var idKey = 'hbdev:' + platformName.toLowerCase() + ':' + this.deviceid;
+    var id = uuid.generate(idKey);
+    Accessory.call(this, this.name, id);
+    var that = this;
+
+    //Removing excluded capabilities from config
+    for (var i = 0; i < device.excludedCapabilities.length; i++) {
+        let excludedCapability = device.excludedCapabilities[i];
+        if (device.capabilities[excludedCapability] !== undefined) {
+            platform.log.debug("Removing capability: " + excludedCapability + " for device: " + device.name);
+            delete device.capabilities[excludedCapability];
+        }
+    }
+    
+    that.addService(CommunityTypes.SmartThingsDeviceIdService, "SmartThings Device ID", "smartthings_device_id");
+    that.getService(CommunityTypes.SmartThingsDeviceIdService)
+        .setCharacteristic(CommunityTypes.DeviceId, device.deviceid);
+
+    that.getService(Service.AccessoryInformation)
+        .setCharacteristic(Characteristic.Identify, (device.capabilities['Switch'] !== undefined))
+        .setCharacteristic(Characteristic.FirmwareRevision, device.firmwareVersion)
+        .setCharacteristic(Characteristic.Manufacturer, device.manufacturerName)
+        .setCharacteristic(Characteristic.Model, `${toTitleCase(device.modelName)}`)
+        .setCharacteristic(Characteristic.Name, that.name)
+        .setCharacteristic(Characteristic.SerialNumber, device.serialNumber);
+
+    this.initializeDeviceCharacteristics(that, device, platform);
+
     this.loadData(device, that);
+
+    return this;
 }
 
 function tempConversion(tUnit, tempVal) {
@@ -1087,7 +1156,7 @@ function loadData(data, myObject) {
             }
         }
     } else {
-        this.log.debug('Fetching Device Data');
+        this.platform.log.debug('Fetching Device Data');
         this.platform.api.getDevice(this.deviceid, function(data) {
             if (data === undefined) {
                 return;
@@ -1104,4 +1173,41 @@ function loadData(data, myObject) {
 
 function getServices() {
     return this.services;
+}
+
+function clearAndSetTimeout(timeoutReference, fn, timeoutMs) {
+    if (timeoutReference) {
+        clearTimeout(timeoutReference);
+    }
+
+    return setTimeout(fn, timeoutMs);
+}
+
+function CreateFromCachedAccessory(accessory, platform) {
+    var service = accessory.getService("SmartThings Device ID");
+    var deviceid = service.getCharacteristic("Device Id").value;
+    var name = accessory.getService(Service.AccessoryInformation).getCharacteristic(Characteristic.Name).value;
+
+    platform.log.debug("Initializing Cached Device " + deviceid);
+
+    accessory.deviceid = deviceid;
+    accessory.name = name
+    accessory.platform = platform;
+    accessory.state = {};
+    accessory.device = null;
+
+    var loadDataFn = loadData.bind(accessory);
+    var firstLoadfn  = function(data, myObject) {
+        if (!this.device) {
+            this.platform.log.debug("Performing first data load and characteristic initialization.");
+            this.device = data;
+            this.initializeDeviceCharacteristics(this, data, this.platform);
+        }
+
+        loadDataFn(data, myObject);
+    }
+
+    accessory.loadData = firstLoadfn.bind(accessory);
+    accessory.getServices = getServices.bind(accessory);
+    accessory.initializeDeviceCharacteristics = initializeDeviceCharacteristics.bind(accessory);
 }

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const platformName = 'SmartThings';
 var he_st_api = require('./lib/he_st_api');
 var http = require('http');
 var os = require('os');
+var inherits = require('util').inherits;
 var Service,
     Characteristic,
     Accessory,
@@ -13,13 +14,14 @@ module.exports = function(homebridge) {
     console.log("Homebridge Version: " + homebridge.version);
     Service = homebridge.hap.Service;
     Characteristic = homebridge.hap.Characteristic;
-    Accessory = homebridge.hap.Accessory;
+    Accessory = homebridge.platformAccessory; //homebridge.hap.Accessory;
     uuid = homebridge.hap.uuid;
+
     HE_ST_Accessory = require('./accessories/he_st_accessories')(Accessory, Service, Characteristic, uuid, platformName);
-    homebridge.registerPlatform(pluginName, platformName, HE_ST_Platform);
+    homebridge.registerPlatform(pluginName, platformName, HE_ST_Platform, true);    
 };
 
-function HE_ST_Platform(log, config) {
+function HE_ST_Platform(log, config, api) {
     this.temperature_unit = 'F';
 
     this.app_url = config['app_url'];
@@ -62,10 +64,20 @@ function HE_ST_Platform(log, config) {
     }
     this.config = config;
     this.api = he_st_api;
+    //this.he_st_api = he_st_api;
+    //this.api = api;
+    this.homekit_api = api;
     this.log = log;
     this.deviceLookup = {};
     this.firstpoll = true;
     this.attributeLookup = {};
+
+    this.homekit_api.on('didFinishLaunching', function() {
+        this.log("Plugin - DidFinishLaunching");
+
+        // Start the refresh from the server
+        this.accessories(this.processAccessoryCallback);
+    }.bind(this));
 }
 
 HE_ST_Platform.prototype = {
@@ -73,9 +85,9 @@ HE_ST_Platform.prototype = {
         var that = this;
         // that.log('config: ', JSON.stringify(this.config));
         var foundAccessories = [];
-        that.log.debug('Refreshing All Device Data');
+        that.log('Refreshing All Device Data');
         he_st_api.getDevices(function(myList) {
-            that.log.debug('Received All Device Data');
+            that.log('Received All Device Data');
             // success
             if (myList && myList.deviceList && myList.deviceList instanceof Array) {
                 var populateDevices = function(devices) {
@@ -83,20 +95,25 @@ HE_ST_Platform.prototype = {
                         var device = devices[i];
                         device.excludedCapabilities = that.excludedCapabilities[device.deviceid] || ["None"];
                         var accessory;
+
+                        that.log.debug("Processing device id: " + device.deviceid);
+
                         if (that.deviceLookup[device.deviceid]) {
+                            that.log("Existing device, loading...");
                             accessory = that.deviceLookup[device.deviceid];
                             accessory.loadData(devices[i]);
                         } else {
+                            that.log.debug("New Device, initializing...");
                             accessory = new HE_ST_Accessory(that, device);
                             // that.log(accessory);
                             if (accessory !== undefined) {
                                 if (accessory.services.length <= 1 || accessory.deviceGroup === 'unknown') {
                                     if (that.firstpoll) {
-                                        that.log('Device Skipped - Group ' + accessory.deviceGroup + ', Name ' + accessory.name + ', ID ' + accessory.deviceid + ', JSON: ' + JSON.stringify(device));
+                                        that.log.debug('Device Skipped - Group ' + accessory.deviceGroup + ', Name ' + accessory.name + ', ID ' + accessory.deviceid + ', JSON: ' + JSON.stringify(device));
                                     }
                                 } else {
                                     // that.log("Device Added - Group " + accessory.deviceGroup + ", Name " + accessory.name + ", ID " + accessory.deviceid); //+", JSON: "+ JSON.stringify(device));
-                                    that.deviceLookup[accessory.deviceid] = accessory;
+                                    that.deviceLookup[device.deviceid] = accessory;
                                     foundAccessories.push(accessory);
                                 }
                             }
@@ -126,8 +143,7 @@ HE_ST_Platform.prototype = {
         this.log('Fetching ' + platformName + ' devices.');
 
         var that = this;
-        // var foundAccessories = [];
-        this.deviceLookup = [];
+
         this.unknownCapabilities = [];
         this.knownCapabilities = [
             'Switch',
@@ -181,7 +197,10 @@ HE_ST_Platform.prototype = {
             'AlarmSystemStatus',
             'Mode',
             'Routine',
-            'Button'
+            'Button',
+            // Sonos Capabilities
+            'Audio Volume',
+            'Audio Mute'
         ];
         if (platformName === 'Hubitat' || platformName === 'hubitat') {
             let newList = [];
@@ -191,10 +210,10 @@ HE_ST_Platform.prototype = {
             this.knownCapabilities = newList;
         }
 
-        he_st_api.init(this.app_url, this.app_id, this.access_token, this.local_hub_ip, this.local_commands);
+        he_st_api.init(this.app_url, this.app_id, this.access_token, this.local_hub_ip, this.local_commands, this.log);
         this.reloadData(function(foundAccessories) {
             that.log('Unknown Capabilities: ' + JSON.stringify(that.unknownCapabilities));
-            callback(foundAccessories);
+            callback.bind(that)(foundAccessories);
             that.log('update_method: ' + that.update_method);
             setInterval(that.reloadData.bind(that), that.polling_seconds * 1000);
             // Initialize Update Mechanism for realtime-ish updates.
@@ -225,7 +244,8 @@ HE_ST_Platform.prototype = {
     },
 
     processIncrementalUpdate: function(data, that) {
-        that.log('new data: ' + data);
+        that.log.debug('new data: ' + data);
+
         if (data && data.attributes && data.attributes instanceof Array) {
             for (var i = 0; i < data.attributes.length; i++) {
                 that.processFieldUpdate(data.attributes[i], that);
@@ -234,8 +254,7 @@ HE_ST_Platform.prototype = {
     },
 
     processFieldUpdate: function(attributeSet, that) {
-        // that.log("Processing Update");
-        // that.log(attributeSet);
+        this.log(attributeSet);
         if (!(that.attributeLookup[attributeSet.attribute] && that.attributeLookup[attributeSet.attribute][attributeSet.device])) {
             return;
         }
@@ -249,8 +268,26 @@ HE_ST_Platform.prototype = {
                 }
             }
         }
+    },
+
+    processAccessoryCallback: function(foundAccessories) {
+        // loop through accessories adding them to the list and registering them
+        for (var i = 0; i < foundAccessories.length; i++) {
+            var accessoryInstance = foundAccessories[i];
+            var accessoryName = accessoryInstance.name; // assume this property was set
+
+            this.log("Initializing platform accessory '%s'...", accessoryName);
+            this.homekit_api.registerPlatformAccessories(pluginName, platformName, [accessoryInstance]);
+        }
     }
 };
+
+HE_ST_Platform.prototype.configureAccessory = function(accessory) {
+    this.log("Configure Cached Accessory: " + accessory.displayName + ", UUID: " + accessory.UUID);
+
+    HE_ST_Accessory.prototype.CreateFromCachedAccessory(accessory, this);
+    this.deviceLookup[accessory.deviceid] = accessory;
+}
 
 function getIPAddress() {
     var interfaces = os.networkInterfaces();

--- a/lib/communityTypes.js
+++ b/lib/communityTypes.js
@@ -280,6 +280,18 @@ module.exports = function(Service, Characteristic) {
     };
     inherits(CommunityTypes.MediaHeight, Characteristic);
 
+    // Custom SmartThings Device Characteristic
+    CommunityTypes.DeviceId = function () {
+        Characteristic.call(this, 'Device Id', '2ecc2a94-30d3-4457-bba7-0a93468de8a4');
+        this.setProps({
+            format: Characteristic.Formats.STRING,
+            perms: [Characteristic.Perms.READ, Characteristic.Perms.WRITE, Characteristic.Perms.HIDDEN]
+        });
+
+        this.value = this.getDefaultValue();
+    };
+    inherits(CommunityTypes.DeviceId, Characteristic);
+
     // Services
 
     CommunityTypes.AudioDeviceService = function(displayName, subtype) {
@@ -372,6 +384,17 @@ module.exports = function(Service, Characteristic) {
         this.addOptionalCharacteristic(Characteristic.StatusTampered);
         this.addOptionalCharacteristic(Characteristic.Name);
     };
+
+    CommunityTypes.SmartThingsDeviceIdService = function(displayName, subtype) {
+        Service.call(this, displayName, '7441b009-ee28-4f29-9a95-f5f6c8ec374a', subtype);
+
+        // Required Characteristics
+        this.addCharacteristic(CommunityTypes.DeviceId);
+
+        // Optional Characteristics
+        this.addOptionalCharacteristic(Characteristic.Name);
+    };
+    inherits(CommunityTypes.SmartThingsDeviceIdService, Service);
 
     return CommunityTypes;
 };

--- a/lib/he_st_api.js
+++ b/lib/he_st_api.js
@@ -4,6 +4,10 @@ const reqPromise = require('request-promise');
 const url = require('url');
 var app_host, app_port, app_path, access_token, localHubIp, useLocalCmds;
 
+var logger = {};
+logger.log = console.log;
+logger.log.debug = console.log;
+
 function _http(data, callback) {
     //console.log("Calling " + platformName);
     var options = {
@@ -19,7 +23,7 @@ function _http(data, callback) {
         options.headers['Content-Type'] = "application/json";
     }
     if (data.debug) {
-        console.log('_http options: ', JSON.stringify(options));
+        logger.log.debug('_http options: ', JSON.stringify(options));
     }
     var str = '';
     var req = http.request(options, function(response) {
@@ -29,14 +33,14 @@ function _http(data, callback) {
 
         response.on('end', function() {
             if (data.debug) {
-                console.log("response in http:", str);
+                logger.log.debug("response in http:", str);
             }
             try {
                 str = JSON.parse(str);
             } catch (e) {
                 if (data.debug) {
-                    console.log(e.stack);
-                    console.log("raw message", str);
+                    logger.log.debug(e.stack);
+                    clogger.log.debug("raw message", str);
                 }
                 str = undefined;
             }
@@ -55,7 +59,7 @@ function _http(data, callback) {
     req.end();
 
     req.on('error', function(e) {
-        console.log("error at req: ", e.message);
+        logger.log.debug("error at req: ", e.message);
         if (callback) {
             callback();
             callback = undefined;
@@ -79,7 +83,7 @@ function _httpLocalPost(data, callback) {
             };
         })
         .catch(function(err) {
-            console.log("reqPromise Error: ", err.message);
+            logger.log.debug("reqPromise Error: ", err.message);
             if (callback) {
                 callback();
                 callback = undefined;
@@ -102,7 +106,11 @@ function GET(data, callback) {
 }
 
 var he_st_api = {
-    init: function(inURL, inAppID, inAccess_Token, hubIp, useLocal = false) {
+    init: function(inURL, inAppID, inAccess_Token, hubIp, useLocal = false, inLog = null) {
+        if (inLog) {
+            logger.log = inLog;
+        }
+
         useLocalCmds = (useLocal === true);
         localHubIp = hubIp;
         var appURL = url.parse(inURL);
@@ -118,6 +126,7 @@ var he_st_api = {
         access_token = inAccess_Token;
     },
     updateGlobals: function(hubIp, useLocal = false) {
+        logger.log.debug("Updating globals: " + hubIp + ", " + useLocal);
         localHubIp = hubIp;
         useLocalCmds = (useLocal === true);
     },
@@ -162,12 +171,12 @@ var he_st_api = {
         });
     },
     runCommand: function(callback, deviceid, command, values) {
-        console.log("[" + platformName + " Plugin Action] Command: " + command + " | Value: " + (values !== undefined ? JSON.stringify(values) : "Nothing") + " | DeviceID: (" + deviceid + ") | local_cmd: " + useLocalCmds);
+        logger.log.debug("[" + platformName + " Plugin Action] Command: " + command + " | Value: " + (values !== undefined ? JSON.stringify(values) : "Nothing") + " | DeviceID: (" + deviceid + ") | local_cmd: " + useLocalCmds);
         let useLocal = (useLocalCmds === true && localHubIp !== undefined && platformName === 'SmartThings');
         let config = {};
         if (useLocal === true) {
             config = {
-                debug: true,
+                debug: false,
                 uri: 'http://' + localHubIp + ':39500/event',
                 body: {
                     deviceid: deviceid,
@@ -196,9 +205,10 @@ var he_st_api = {
     },
     startDirect: function(callback, myIP, myPort) {
         let useLocal = (useLocalCmds === true && localHubIp !== undefined && platformName === 'SmartThings');
+
         if (useLocal) {
             POST({
-                debug: true,
+                debug: false,
                 uri: 'http://' + localHubIp + ':39500/event',
                 body: {
                     ip: myIP,

--- a/package.json
+++ b/package.json
@@ -1,25 +1,55 @@
 {
+  "_from": "homebridge-smartthings-tonesto7@1.5.10",
+  "_id": "homebridge-smartthings-tonesto7@1.5.10",
+  "_inBundle": false,
+  "_integrity": "sha512-PlYgKCp34xR2JeOf3oB9wugGXDemtl1vhY9Rw/jRSHMPraVFIElqK6TvnKtN8mutlYscRSdY5oUdKQJbSiVcjg==",
+  "_location": "/homebridge-smartthings-tonesto7",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "version",
+    "registry": true,
+    "raw": "homebridge-smartthings-tonesto7@1.5.10",
     "name": "homebridge-smartthings-tonesto7",
-    "description": "SmartThings plugin for HomeBridge",
-    "version": "1.5.10",
-    "license": "ISC",
-    "preferGlobal": true,
-    "keywords": [
-        "homebridge-plugin",
-        "smartthings",
-        "homekit",
-        "homebridge"
-    ],
-    "dependencies": {
-        "request": "^2.88.0",
-        "request-promise": "^4.2.4"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/tonesto7/homebridge-smartthings-tonesto7.git"
-    },
-    "engines": {
-        "node": ">=0.12.0",
-        "homebridge": ">=0.3.1"
-    }
+    "escapedName": "homebridge-smartthings-tonesto7",
+    "rawSpec": "1.5.10",
+    "saveSpec": null,
+    "fetchSpec": "1.5.10"
+  },
+  "_requiredBy": [
+    "#USER",
+    "/"
+  ],
+  "_resolved": "https://registry.npmjs.org/homebridge-smartthings-tonesto7/-/homebridge-smartthings-tonesto7-1.5.10.tgz",
+  "_shasum": "d50f6202ad507ffe8e93c6a2bb4c171b6e4096d9",
+  "_spec": "homebridge-smartthings-tonesto7@1.5.10",
+  "_where": "/Users/ianoberst/.homebridge/accessories",
+  "bugs": {
+    "url": "https://github.com/tonesto7/homebridge-smartthings-tonesto7/issues"
+  },
+  "bundleDependencies": false,
+  "dependencies": {
+    "request": "^2.88.0",
+    "request-promise": "^4.2.4"
+  },
+  "deprecated": false,
+  "description": "SmartThings plugin for HomeBridge",
+  "engines": {
+    "homebridge": ">=0.3.1",
+    "node": ">=0.12.0"
+  },
+  "homepage": "https://github.com/tonesto7/homebridge-smartthings-tonesto7#readme",
+  "keywords": [
+    "homebridge-plugin",
+    "smartthings",
+    "homekit",
+    "homebridge"
+  ],
+  "license": "ISC",
+  "name": "homebridge-smartthings-tonesto7",
+  "preferGlobal": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tonesto7/homebridge-smartthings-tonesto7.git"
+  },
+  "version": "1.5.10"
 }

--- a/smartapps/tonesto7/homebridge-smartthings.src/homebridge-smartthings.groovy
+++ b/smartapps/tonesto7/homebridge-smartthings.src/homebridge-smartthings.groovy
@@ -5,12 +5,11 @@
  */
 
 String appVersion() { return "1.5.5" }
-String appModified() { return "10-16-2019" }
+String appModified() { return "06-10-2019" }
 String platform() { return "SmartThings" }
 String appIconUrl() { return "https://raw.githubusercontent.com/tonesto7/homebridge-smartthings-tonesto7/master/images/hb_tonesto7@2x.png" }
 String getAppImg(imgName) { return "https://raw.githubusercontent.com/tonesto7/smartthings-tonesto7-public/master/resources/icons/$imgName" }
 Boolean isST() { return (platform() == "SmartThings") }
-
 definition(
     name: "Homebridge (${platform()})",
     namespace: "tonesto7",
@@ -21,6 +20,7 @@ definition(
     iconX2Url: "https://raw.githubusercontent.com/tonesto7/homebridge-smartthings-tonesto7/master/images/hb_tonesto7@2x.png",
     iconX3Url: "https://raw.githubusercontent.com/tonesto7/homebridge-smartthings-tonesto7/master/images/hb_tonesto7@3x.png",
     oauth: true)
+
 
 preferences {
     page(name: "mainPage")
@@ -636,15 +636,15 @@ def deviceCapabilityList(device) {
         }
         if(remTemp) { items.remove("Temperature Measurement") }
     }
-    if(settings.removeBattery && items["Battery"] && isDeviceInInput('removeBattery', device?.id)) { items.remove("Battery"); }// log.debug "Filtering Battery" }
-    if(settings.removeSwitch && items["Switch"] && isDeviceInInput('removeSwitch', device?.id)) { items.remove("Switch"); } //log.debug "Filtering Switch" }
-    if(settings.removeTemp && items["Temperature Measurement"] && isDeviceInInput('removeTemp', device?.id)) { items.remove("Temperature Measurement"); } //log.debug "Filtering Temp" }
-    if(settings.removeContact && items["Contact Sensor"] && isDeviceInInput('removeContact', device?.id)) { items.remove("Contact Sensor"); }// log.debug "Filtering Contact" }
-    if(settings.removeLevel && items["Switch Level"] && isDeviceInInput('removeLevel', device?.id)) { items.remove("Switch Level"); }//log.debug "Filtering Level" }
-    if(settings.removeMotion && items["Motion Sensor"] && isDeviceInInput('removeMotion', device?.id)) { items.remove("Motion Sensor"); } //log.debug "Filtering Motion" }
-    if(settings.removePower && items["Power Meter"] && isDeviceInInput('removePower', device?.id)) { items.remove("Power Meter"); } //log.debug "Filtering Power Meter" }
-    if(settings.removePresence && items["Presence Sensor"] && isDeviceInInput('removePresence', device?.id)) { items.remove("Presence Sensor"); }//log.debug "Filtering Presence" }
-    if(settings.removeTamper && items["Tamper Alert"] && isDeviceInInput('removeTamper', device?.id)) { items.remove("Tamper Alert"); }// log.debug "Filtering Tamper" }
+    if(settings.removeBattery && items["Battery"] && isDeviceInInput('removeBattery', device?.id)) { items.remove("Battery"); log.debug "Filtering Battery" }
+    if(settings.removeSwitch && items["Switch"] && isDeviceInInput('removeSwitch', device?.id)) { items.remove("Switch"); log.debug "Filtering Switch" }
+    if(settings.removeTemp && items["Temperature Measurement"] && isDeviceInInput('removeTemp', device?.id)) { items.remove("Temperature Measurement"); log.debug "Filtering Temp" }
+    if(settings.removeContact && items["Contact Sensor"] && isDeviceInInput('removeContact', device?.id)) { items.remove("Contact Sensor"); log.debug "Filtering Contact" }
+    if(settings.removeLevel && items["Switch Level"] && isDeviceInInput('removeLevel', device?.id)) { items.remove("Switch Level"); log.debug "Filtering Level" }
+    if(settings.removeMotion && items["Motion Sensor"] && isDeviceInInput('removeMotion', device?.id)) { items.remove("Motion Sensor"); log.debug "Filtering Motion" }
+    if(settings.removePower && items["Power Meter"] && isDeviceInInput('removePower', device?.id)) { items.remove("Power Meter"); log.debug "Filtering Power Meter" }
+    if(settings.removePresence && items["Presence Sensor"] && isDeviceInInput('removePresence', device?.id)) { items.remove("Presence Sensor"); log.debug "Filtering Presence" }
+    if(settings.removeTamper && items["Tamper Alert"] && isDeviceInInput('removeTamper', device?.id)) { items.remove("Tamper Alert"); log.debug "Filtering Tamper" }
     return items
 }
 
@@ -803,12 +803,12 @@ def changeHandler(evt) {
 
     if (sendEvt && state?.directIP != "" && sendItems?.size()) {
         //Send Using the Direct Mechanism
-        sendItems?.each { si->
+        sendItems?.each { send->
             if(settings?.showLogs) {
                 String unitStr = ""
-                switch(sendItems?.evtAttr as String) {
+                switch(send?.evtAttr as String) {
                     case "temperature":
-                        unitStr = "\u00b0${si?.evtUnit}"
+                        unitStr = "\u00b0${send?.evtUnit}"
                         break
                     case "humidity":
                     case "level":
@@ -822,10 +822,10 @@ def changeHandler(evt) {
                         unitStr = " Lux"
                         break
                     default:
-                        unitStr = si?.evtUnit ?: ""
+                        unitStr = "${send?.evtUnit}"
                         break
                 }
-                log.debug "Sending${" ${si?.evtSource}" ?: ""} Event (${si?.evtDeviceName} | ${si?.evtAttr.toUpperCase()}: ${si?.evtValue}${unitStr}) to Homebridge at (${state?.directIP}:${state?.directPort})"
+                log.debug "Sending${" ${send?.evtSource}" ?: ""} Event (${send?.evtDeviceName} | ${send?.evtAttr.toUpperCase()}: ${send?.evtValue}${unitStr}) to Homebridge at (${state?.directIP}:${state?.directPort})"
             }
             def params = [
                 method: "POST",
@@ -835,11 +835,11 @@ def changeHandler(evt) {
                     'Content-Type': 'application/json'
                 ],
                 body: [
-                    change_name: si?.evtDeviceName,
-                    change_device: si?.evtDeviceId,
-                    change_attribute: si?.evtAttr,
-                    change_value: si?.evtValue,
-                    change_date: si?.evtDate
+                    change_name: send?.evtDeviceName,
+                    change_device: send?.evtDeviceId,
+                    change_attribute: send?.evtAttr,
+                    change_value: send?.evtValue,
+                    change_date: send?.evtDate
                 ]
             ]
             def result = new physicalgraph.device.HubAction(params)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This issue is a fix for issue #13 

Added new code to support the updated Homebridge API that allows devices to be loaded from the device cache and dynamically added and removed based on the device availability.

I also added some basic support for Sonos devices via SmartThings, which I can remove if considered out of scope for the API changes. (It doesn't really do a whole lot since HomeKit doesn't support speakers...yay.)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] My code follows the code style of this project.
-   [X] My change requires a change to the documentation.

The caching will cause old devices to persist after they are removed as they are in the Homebridge cache. This is the case with any plugins that use the newer API unless a way is provided to definitively know that a device was removed. This can be resolved by removing the old devices manually from the Homebridge cache.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

This is not a breaking change, but the device cache for Homebridge _may_ need to be cleared of devices that are already present. If the devices have not been previously cached, then that should not be necessary, though a restart will cause the device information to be lost as it wasn't previously cached, per issue #13 . After the first run with the changes the information will be cached and will no longer be lost during restarts.

## Description of Changes

- Split out portions of the accessory initialization to support being created from the cache.
- Added experimental support for Sonos speakers
- Adjusted the logging to allow for passing in the platform logger to some modules to better track debugging
- Added a new, custom characteristic to track the Device Id for matching items coming from the hub to items initialized from the cache.
- Added a new custom service to hold the Device Id characteristic
- Implemented the new API features to allow loading cached devices

## Reason for Change

Losing power to the SmartThings hub or Homebridge would cause device information to be reset, and automations to stop working. This change allows for the devices to restore without that loss.

## How Has This Been Tested?

I have been running the changes on my local Homebridge/SmartThings setup for nearly two months without issue. I also tested several common scenarios, such as sudden loss of power, system restarts, etc.

## Screenshots (if appropriate):
