### PR TITLE
simple implementation of new Air Purifiers control

### DIFF
--- a/lib/communityTypes.js
+++ b/lib/communityTypes.js
@@ -280,6 +280,25 @@ module.exports = function(Service, Characteristic) {
     };
     inherits(CommunityTypes.MediaHeight, Characteristic);
 
+    CommunityTypes.FanOscilationMode = function() {
+        Characteristic.call(this, 'RotationSpeed', '00000029-0000-1000-8000-0026BB765291');
+        this.setProps({
+            format: Characteristic.Formats.UINT8,
+            maxValue: 100,
+            minValue: 0,
+            validValues: [25,50,75,100],
+            perms: [Characteristic.Perms.READ,Characteristic.Perms.WRITE, Characteristic.Perms.NOTIFY]
+        });
+        this.value = this.getDefaultValue();
+    };
+    inherits(CommunityTypes.FanOscilationMode, Characteristic.RotationSpeed);
+
+    // The value property of FanOscilationMode must be one of the following:
+    CommunityTypes.FanOscilationMode.SLEEP  = 25;
+    CommunityTypes.FanOscilationMode.LOW    = 50;
+    CommunityTypes.FanOscilationMode.MEDIUM = 75;
+    CommunityTypes.FanOscilationMode.HIGH   = 100;
+
     // Services
 
     CommunityTypes.AudioDeviceService = function(displayName, subtype) {
@@ -372,6 +391,21 @@ module.exports = function(Service, Characteristic) {
         this.addOptionalCharacteristic(Characteristic.StatusTampered);
         this.addOptionalCharacteristic(Characteristic.Name);
     };
+
+    CommunityTypes.NewAirPurifierService = function(displayName, subtype) {
+        Service.call(this, displayName, '000000BB-0000-1000-8000-0026BB765291', subtype);
+
+        // Required Characteristics
+        this.addCharacteristic(Characteristic.Active);
+        this.addCharacteristic(Characteristic.CurrentAirPurifierState);
+        this.addCharacteristic(Characteristic.TargetAirPurifierState);
+        this.addCharacteristic(CommunityTypes.FanOscilationMode);
+
+        // Optional Characteristics
+        this.addOptionalCharacteristic(Characteristic.Name);
+    };
+    inherits(CommunityTypes.NewAirPurifierService, Service.AirPurifier);
+   
 
     return CommunityTypes;
 };


### PR DESCRIPTION
This is very simple implementation of new Air Purifiers control - power and speed. Example new device that was released in September 2019 is AX60R5080WD - it has new API.

## Checklist:

-   [X] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description of Changes

Adds `CommunityTypes.NewAirPurifierService` service fot controlling device and supporting `CommunityTypes.FanOscilationMode` type to provide high-medium-low-sleep modes.

As of main routine I added `isAirPurifier` variable and logic to add power and speed controls for device.

## Reason for Change

Add new class of devices.

## How Has This Been Tested?

Weeks of tests on device I own.

## Screenshots (if appropriate): N/A
